### PR TITLE
fix: remove abs costchange from LM

### DIFF
--- a/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
+++ b/gtsam/nonlinear/LevenbergMarquardtOptimizer.cpp
@@ -189,7 +189,7 @@ bool LevenbergMarquardtOptimizer::tryLambda(const GaussianFactorGraph& linear,
              << ")" << endl;
 
       // cost change in the original, nonlinear system (old - new)
-      costChange = std::abs(currentState->error - newError);
+      costChange = currentState->error - newError;
 
       if (linearizedCostChange > std::numeric_limits<double>::epsilon() * oldLinearizedError) {
         // the (linear) error has to decrease to satisfy this condition


### PR DESCRIPTION
In the previous commit, we made the costChange in the LM method an absolute value, but it is unnecessary because lambda is not adjusted as error grows in the LM method.